### PR TITLE
Implement sticky navigation on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-	<header>
+	<header class="scroll-sticky-navigation">
 		<nav class="nav-bar container">
 			<i class="bx bx-menu hamburger-icon"></i>
 			<div class="brand">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,3 @@
 import './sass/main.scss';
 import './ts/components/_menu';
+import './ts/components/_scroll_sticky_navigation';

--- a/src/sass/abstracts/_variables.scss
+++ b/src/sass/abstracts/_variables.scss
@@ -31,5 +31,6 @@
     --animation-duration: 500ms;
 
     --hundred: 100%;
+    --minus-hundred: -100%;
     --minus-two-hundred: -200%;
 }

--- a/src/sass/components/_scroll_sticky_navigation.scss
+++ b/src/sass/components/_scroll_sticky_navigation.scss
@@ -1,0 +1,24 @@
+.scroll-sticky-navigation {
+    position: sticky;
+    top: 0;
+    @include transitionEaseInOut;
+
+    // Remove below rules if scrolling sticky navigation
+    // feature is not needed. Sticky navigation will still
+    // work without scrolling sticky effect.
+    &.scroll-up,
+    &:focus-within {
+        @include translate();
+    }
+
+    &.scroll-down {
+        @include translate(vertical, var(--minus-hundred));
+    }
+}
+
+// To add padding when user clicks on a link to scroll to a specific section.
+html {
+    // scroll-padding-top is a built-in CSS property like
+    // scroll-behavior property for a better scroll experience.
+    scroll-padding-top: var(--scroll-padding, 50px);
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -9,6 +9,7 @@
 @import 'components/button';
 @import 'components/form';
 @import 'components/project';
+@import 'components/scroll_sticky_navigation';
 @import './base/animations';
 @import 'pages/index';
 @import 'pages/work';

--- a/src/ts/components/_scroll_sticky_navigation.ts
+++ b/src/ts/components/_scroll_sticky_navigation.ts
@@ -1,0 +1,56 @@
+const scrollStickyNav: HTMLElement = document.querySelector('.scroll-sticky-navigation') as HTMLElement;
+// Initialize the previous scroll position to zero
+let previousScrollPosition: number = 0;
+// To control the throttling of the scroll event
+let isThrottling: boolean;
+
+
+function getScrolledPosition(): number {
+    return window.scrollY;
+}
+
+const isScrollingDown = (): boolean => {
+    const scrolledPosition = getScrolledPosition();
+    const isScrollDown: boolean = scrolledPosition > previousScrollPosition;
+
+    // Temporarily solution to fix the issue with the sticky navbar
+    // when clicking on the hamburger menu to show the navbar links
+    // on tablet and mobile. 100 is a random number and it works fine.
+    previousScrollPosition = scrolledPosition + 100;
+    return isScrollDown;
+};
+
+const handleNavScroll = () => {
+    if (isScrollingDown() && !scrollStickyNav?.contains(document.activeElement)) {
+        scrollStickyNav?.classList.add('scroll-down');
+        scrollStickyNav?.classList.remove('scroll-up');
+    } else {
+        scrollStickyNav?.classList.add('scroll-up');
+        scrollStickyNav?.classList.remove('scroll-down');
+    }
+};
+
+const throttleTimer = (callback: Function, time: number) => {
+    if (isThrottling) return;
+
+    isThrottling = true;
+    setTimeout(() => {
+        callback();
+        isThrottling = false;
+    }, time);
+};
+
+const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+window.addEventListener('scroll', () => {
+    if (mediaQuery && !mediaQuery.matches) {
+        throttleTimer(handleNavScroll, 750);
+    }
+});
+
+// To fix the navigation covering content on scroll
+// when user clicks on a link to scroll to a specific section.
+const navigationHeight = scrollStickyNav.offsetHeight;
+document.documentElement.style.setProperty(
+    '--scroll-padding',
+    `${navigationHeight}px`
+);

--- a/work.html
+++ b/work.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-  <header>
+  <header class="scroll-sticky-navigation">
 		<nav class="nav-bar container">
 			<i class="bx bx-menu hamburger-icon"></i>
 			<div class="brand">


### PR DESCRIPTION
Hide the navigation bar when the user scrolls down and show it when the user scrolls up. This improves the user experience and saves screen space.