### PR TITLE
Hide the load more projects button

### DIFF
--- a/src/components/project/Project.ts
+++ b/src/components/project/Project.ts
@@ -24,4 +24,5 @@ loadMoreProjects.addEventListener('click', async () => {
       showProjectsMarkup
     );
   addClassTo(loader);
+  addClassTo(loadMoreProjects);
 })


### PR DESCRIPTION
Hide the button so that it doesn't fetch the same data again because in the first fetch in retrieves all the data.